### PR TITLE
Fix a compilation error

### DIFF
--- a/OAuthSwift-Alamofire/Manager+OAuthSwift.swift
+++ b/OAuthSwift-Alamofire/Manager+OAuthSwift.swift
@@ -31,7 +31,7 @@ extension Manager {
 
     public func request(URLRequest: URLRequestConvertible, credential: OAuthSwiftCredential) -> Request {
         let request = URLRequest.URLRequest
-        request.addOAuthHeader(credential)
+        request.addOAuthHeaderWithCredential(credential)
         let requestConvertible: URLRequestConvertible = request
         return self.request(requestConvertible)
     }


### PR DESCRIPTION
The current code cannot compile because the wrong method is called to populate the request with OAuth headers (addOAuthHeader instead of addOAuthHeaderWithCredential)
