### PR TITLE
Fix refresh token

### DIFF
--- a/Sources/OAuthSwiftRequestAdapter.swift
+++ b/Sources/OAuthSwiftRequestAdapter.swift
@@ -76,7 +76,7 @@ open class OAuthSwift2RequestAdapter: OAuthSwiftRequestAdapter, RequestRetrier {
         
         
         oauth2Swift.renewAccessToken(
-            withRefreshToken: "",
+            withRefreshToken: oauth2Swift.client.credential.oauthRefreshToken,
             success: { [weak self] (credential, response, parameters) in
                 guard let strongSelf = self else { return }
                 completion(true)


### PR DESCRIPTION
Fix for issue #8 . I'm not sure if this fix is the best solution, but it works. Previously it was sending an empty string as the refresh token

Additionally, I'm wondering if something should be done to make it easier to know when the token was refreshed so that keychain can be updated? Right now there wouldn't be any easy way except to check on every request.