### PR TITLE
Set the EMBEDDED_CONTENT_CONTAINS_SWIFT flag to false

### DIFF
--- a/OAuthSwift-Alamofire.xcodeproj/project.pbxproj
+++ b/OAuthSwift-Alamofire.xcodeproj/project.pbxproj
@@ -716,7 +716,7 @@
 		C4D7F9481BB7585900A6D40E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -742,7 +742,7 @@
 		C4D7F9491BB7585900A6D40E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
I had a problem submitting an app built using Carthage. The problem was that the framework contained the folder Frameworks which is not allowed. This is fixed by setting the parent project flag EMBEDDED_CONTENT_CONTAINS_SWIFT to true and the other projects to false.

![yjrpt](https://user-images.githubusercontent.com/441974/44885209-dc53a380-acbf-11e8-8c09-b881cc08ed22.png)

